### PR TITLE
Update Json.php

### DIFF
--- a/src/Umpirsky/ListGenerator/Exporter/Format/Json.php
+++ b/src/Umpirsky/ListGenerator/Exporter/Format/Json.php
@@ -11,6 +11,6 @@ class Json extends Exporter
      */
     public function export(array $data)
     {
-        return json_encode($data);
+        return json_encode($data, JSON_UNESCAPED_UNICODE);
     }
 }


### PR DESCRIPTION
- Add export option JSON_UNESCAPED_UNICODE


Hi. I'm Maro.

I added some Unicode option for the JSON exporter.

Without this option, Some languages are exported in Unicode instead of their language such as Chinese, Korean, Japanese.

For example: 👇👇

https://github.com/umpirsky/country-list/blob/master/data/ko_KR/country.php
https://github.com/umpirsky/country-list/blob/master/data/ko_KR/country.json

https://github.com/umpirsky/country-list/blob/master/data/zh_CN/country.php
https://github.com/umpirsky/country-list/blob/master/data/zh_CN/country.json

https://github.com/umpirsky/country-list/blob/master/data/ja_JP/country.php
https://github.com/umpirsky/country-list/blob/master/data/ja_JP/country.json

(Yeah I know you can't read that languages, but You will know what I want to say.)

Thanks